### PR TITLE
Example AWS Terraform templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.terraform
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars
+backend.tfvars

--- a/primary-site/aws/README.md
+++ b/primary-site/aws/README.md
@@ -1,48 +1,102 @@
-## AWS provider
+# Primary Site AWS Terraform Example Templates
 
-### Create credentials
+Use these templates to create resources for a Foxglove Primary Site.
 
-1.1. Terraform needs an administrator user's account ID & secret for an AWS provider. To create
-IAM credentials manually, navigate to IAM:
-https://us-east-1.console.aws.amazon.com/iamv2/home
+## Overview
 
-And add a new user:
+Once the resources are created, you'll be able to deploy the Helm charts into the created
+EKS cluster, and use the included S3 buckets for inbox and lake.
+
+The template's IAM user is created with programmatic access, which can be used in the
+Kubernetes cluster's `cloud-credentials` secret, allowing the services to connect to the inbox
+and lake buckets.
+
+## Getting started
+
+### Create resources for the Terraform provider
+
+Terraform needs an administrator user's account ID and account secret for its AWS provider. To
+create IAM credentials manually, navigate to [IAM](https://us-east-1.console.aws.amazon.com/iamv2/home)
+
+Add a new user:
 * Select `Access key - Programmatic access`
 * Attach the `AdministratorAccess` policy directly
 * Record the credentials or download them in a CSV
 
-1.2. It's also best practice on aws to store the Terraform state on S3. This will be used to store
-the tfstate rather than keeping them locally. Any S3 bucket will do:
-* Block all public access; tfstate often contains secrets
-* Region to match IAM user's (not a must, but makes life easier)
+It's also best practice on aws to store the Terraform state on S3. This will be used to store
+the `tfstate` in the cloud, rather than keeping them locally. Create an S3 bucket, and make
+sure to block all public access (the tfstate will contain secrets).
 
-### Use these settings
+### Use these credentials
 
 Terraform can use these crendetials from env variables, or using the cli's configuration.
 One simple option is to use [aws-cli](https://aws.amazon.com/cli/) and run `aws configure`
 Read more: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
-The provider in this package will pick up the default credentials automagically.
+The provider in this Terraform package will pick up the default credentials.
+
+### Run Terraform
+
+Configure the variables. Note that some of them you'll find on the Foxglove console's
+[Settings page](https://console.foxglove.party/organization?tab=sites), under the Sites
+tab.
 
 1. Copy `terraform.tfvars-example` to `terraform.tfvars`
-2. Change the "changeme" text to your own username
+2. Use the `inbox_notification_endpoint` variable from the Foxglove Console's site settings.
+2. Change the other variables as needed
 3. Copy `backend.tfvars-example` to `backend.tfvars`
-4. Set the bucket name and region to what was created above; key can be any object key.
+4. Set the bucket name and region to what was created in the "Getting started" step; key can
+   be any object key.
 5. Run `terraform init --backend-config backend.tfvars`
 
 You should now be able to run `terraform plan` and `terraform apply`.
 
+## Modules
+
+- `iam`: creates an IAM user with programmatic access. The credentials will be in `tfstate` as
+         as sensitive output values. Use these for the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+         environment variables in the `cloud-credentials` secret, as described in the
+         [Configure Cloud Credentials](https://foxglove.dev/docs/data-platform/primary-sites/configure-cloud-credentials)
+         section.
+         This user has access to read/write both the `inbox` and `lake` S3 buckets.
+
+- `s3`: creates an S3 bucket with private access. This module is used to create the `inbox` and
+        `lake` buckets.
+
+- `sns`: creates an SNS topic with a https subscription, and attaches it to an S3 bucket's
+         `s3:ObjectCreated:*` events. Whenever a new object appears in the bucket, the webhook
+         `inbox_notification_endpoint` will be notified.
+
+## Production use
+
+This Terraform example creates all resources that are needed for a working Foxglove Primary
+Site deployment: the VPC, EKS cluster, IAM user, S3 buckets and the SNS topic. For production
+use, consider the following:
+
+### Connecting to the cluster
+
+By default, only the creator Terraform user will be able to connect to this EKS cluster.
+Read the AWS docs about [adding other IAM users and roles](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html),
+or set `manage_aws_auth_configmap = true` in the eks module (will require setting up the
+"kubernetes" provider).
 
 ### AWS Load Balancer Controller
 
-The [AWS Load Balancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
-manages AWS Elastic Load Balancers for a Kubernetes cluster. The controller provisions an
-AWS Application Load Balancer (ALB) when a Kubernetes Ingress is created. 
+TO provisions an AWS Application Load Balancer (ALB) when a Kubernetes Ingress is created,
+the AWS Load Balancer Controller needs to be installed in the cluster. Follow the
+[AWS user guide](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
+to set up this add-on.
 
-### A note on Fargate
+### CoreDns on Fargate
 
-There is a managed node in the EKS example, and only foxglove resources (in the `foxglove`
-namespace) will run on Fargate (see the Fargate profile in the example). If the managed node
-is removed from the example, the default CoreDns will need to be updated; see [this guide](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/deploy-coredns-on-amazon-eks-with-fargate-automatically-using-terraform-and-python.html).
+In the example, the EKS module is set up with both a managed node and Fargate profiles.
+The Fargate profile assume that the Foxglove resources will be deployed in the `foxglove`
+namespace, and therefore run on Fargate.
 
-Similarly, logging from the Fargate payloads requires setting up FluentBit as per [this guide](https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html).
+One corner case around nodes in EKS is that if the managed node is removed from the template,
+the default CoreDns service will need to be patched; see [this guide](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/deploy-coredns-on-amazon-eks-with-fargate-automatically-using-terraform-and-python.html) for details.
+
+### Logging on Fargate
+
+Sending logs to CloudWatch from Fargate payloads requires setting up FluentBit as per
+[this guide](https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html).

--- a/primary-site/aws/README.md
+++ b/primary-site/aws/README.md
@@ -31,3 +31,18 @@ The provider in this package will pick up the default credentials automagically.
 5. Run `terraform init --backend-config backend.tfvars`
 
 You should now be able to run `terraform plan` and `terraform apply`.
+
+
+### AWS Load Balancer Controller
+
+The [AWS Load Balancer Controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
+manages AWS Elastic Load Balancers for a Kubernetes cluster. The controller provisions an
+AWS Application Load Balancer (ALB) when a Kubernetes Ingress is created. 
+
+### A note on Fargate
+
+There is a managed node in the EKS example, and only foxglove resources (in the `foxglove`
+namespace) will run on Fargate (see the Fargate profile in the example). If the managed node
+is removed from the example, the default CoreDns will need to be updated; see [this guide](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/deploy-coredns-on-amazon-eks-with-fargate-automatically-using-terraform-and-python.html).
+
+Similarly, logging from the Fargate payloads requires setting up FluentBit as per [this guide](https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html).

--- a/primary-site/aws/README.md
+++ b/primary-site/aws/README.md
@@ -1,0 +1,33 @@
+## AWS provider
+
+### Create credentials
+
+1.1. Terraform needs an administrator user's account ID & secret for an AWS provider. To create
+IAM credentials manually, navigate to IAM:
+https://us-east-1.console.aws.amazon.com/iamv2/home
+
+And add a new user:
+* Select `Access key - Programmatic access`
+* Attach the `AdministratorAccess` policy directly
+* Record the credentials or download them in a CSV
+
+1.2. It's also best practice on aws to store the Terraform state on S3. This will be used to store
+the tfstate rather than keeping them locally. Any S3 bucket will do:
+* Block all public access; tfstate often contains secrets
+* Region to match IAM user's (not a must, but makes life easier)
+
+### Use these settings
+
+Terraform can use these crendetials from env variables, or using the cli's configuration.
+One simple option is to use [aws-cli](https://aws.amazon.com/cli/) and run `aws configure`
+Read more: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+
+The provider in this package will pick up the default credentials automagically.
+
+1. Copy `terraform.tfvars-example` to `terraform.tfvars`
+2. Change the "changeme" text to your own username
+3. Copy `backend.tfvars-example` to `backend.tfvars`
+4. Set the bucket name and region to what was created above; key can be any object key.
+5. Run `terraform init --backend-config backend.tfvars`
+
+You should now be able to run `terraform plan` and `terraform apply`.

--- a/primary-site/aws/README.md
+++ b/primary-site/aws/README.md
@@ -82,7 +82,7 @@ or set `manage_aws_auth_configmap = true` in the eks module (will require settin
 
 ### AWS Load Balancer Controller
 
-TO provisions an AWS Application Load Balancer (ALB) when a Kubernetes Ingress is created,
+To provisions an AWS Application Load Balancer (ALB) when a Kubernetes Ingress is created,
 the AWS Load Balancer Controller needs to be installed in the cluster. Follow the
 [AWS user guide](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
 to set up this add-on.

--- a/primary-site/aws/backend.tfvars-example
+++ b/primary-site/aws/backend.tfvars-example
@@ -1,0 +1,3 @@
+bucket = "terraform-state-fg-CHANGEME"
+region = "us-east-1"
+key    = "dataplatform/CHANGEME/terraform.tfstate"

--- a/primary-site/aws/main.tf
+++ b/primary-site/aws/main.tf
@@ -29,3 +29,90 @@ module "iam" {
   inbox_bucket_arn = module.s3_inbox.bucket_arn
   iam_user_name    = var.primarysite_iam_user_name
 }
+
+## ----- VPC -----
+
+data "aws_availability_zones" "available" {}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.14.2"
+
+  name = var.vpc_name
+
+  # EKS VPC and subnet requirements and considerations
+  # https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html
+  cidr            = "10.0.0.0/16"
+  azs             = slice(data.aws_availability_zones.available.names, 0, 3)
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  # Fargate requirements:
+  # https://docs.aws.amazon.com/eks/latest/userguide/eks-ug.pdf#page=135&zoom=100,96,764
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_vpn_gateway   = false
+
+  # NOTE tagging for automatic subnet discovery by load balancers or ingress controllers
+  # https://aws.amazon.com/premiumsupport/knowledge-center/eks-vpc-subnet-discovery/
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${var.eks_cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                        = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${var.eks_cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"               = 1
+  }
+}
+
+## ----- EKS cluster & instance security groups -----
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "18.30.2"
+
+  cluster_name                    = var.eks_cluster_name
+  cluster_version                 = "1.24"
+  cluster_endpoint_private_access = true
+  cluster_endpoint_public_access  = true
+
+  cluster_addons = {
+    kube-proxy = {}
+    vpc-cni    = {}
+  }
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  # Fargate profiles use the cluster primary security group, so these are not utilized
+  create_cluster_security_group = false
+  create_node_security_group    = false
+
+  eks_managed_node_group_defaults = {
+    ami_type                              = "AL2_x86_64"
+    attach_cluster_primary_security_group = true
+    create_security_group                 = false
+  }
+
+  eks_managed_node_groups = {
+    default = {
+      name         = "default-node-group"
+      min_size     = 0
+      max_size     = 2
+      desired_size = 1
+
+      instance_types = ["t3.small"]
+    }
+  }
+
+  fargate_profiles = {
+    foxglove = {
+      create_iam_role = true
+      name            = "foxglove"
+      selectors       = [{ namespace = "foxglove" }]
+    }
+  }
+}

--- a/primary-site/aws/main.tf
+++ b/primary-site/aws/main.tf
@@ -1,0 +1,31 @@
+## ----- S3 buckets -----
+
+module "s3_lake" {
+  source      = "./modules/s3"
+  bucket_name = var.lake_bucket_name
+}
+
+module "s3_inbox" {
+  source      = "./modules/s3"
+  bucket_name = var.inbox_bucket_name
+}
+
+## ----- Pubsub -----
+
+module "inbox_sns_notification" {
+  source     = "./modules/sns"
+  bucket_arn = module.s3_inbox.bucket_arn
+  bucket_id  = module.s3_inbox.bucket_id
+  topic_name = "${var.inbox_bucket_name}-sns-topic"
+
+  inbox_notification_endpoint = var.inbox_notification_endpoint
+}
+
+## ----- IAM Credentials -----
+
+module "iam" {
+  source           = "./modules/iam"
+  lake_bucket_arn  = module.s3_lake.bucket_arn
+  inbox_bucket_arn = module.s3_inbox.bucket_arn
+  iam_user_name    = var.primarysite_iam_user_name
+}

--- a/primary-site/aws/main.tf
+++ b/primary-site/aws/main.tf
@@ -109,6 +109,9 @@ module "eks" {
   }
 
   fargate_profiles = {
+    # This Fargate profile assumes that the Foxglove resources will be deployed in
+    # the `foxglove` namespace. All workloads in this namespace will be run by the
+    # Fargate scheduler.
     foxglove = {
       create_iam_role = true
       name            = "foxglove"

--- a/primary-site/aws/modules/iam/main.tf
+++ b/primary-site/aws/modules/iam/main.tf
@@ -1,0 +1,58 @@
+data "aws_iam_policy_document" "policy_document" {
+  statement {
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ]
+    resources = [
+      var.lake_bucket_arn,
+      var.inbox_bucket_arn,
+    ]
+    effect = "Allow"
+  }
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject"
+    ]
+    resources = [
+      var.lake_bucket_arn,
+      "${var.lake_bucket_arn}/*",
+      var.inbox_bucket_arn,
+      "${var.inbox_bucket_arn}/*",
+    ]
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "policy" {
+  name   = "${var.iam_user_name}-policy"
+  path   = "/"
+  policy = data.aws_iam_policy_document.policy_document.json
+}
+
+# Admin user for Terraform to access this sub-org
+resource "aws_iam_user" "iam_user" {
+  name          = var.iam_user_name
+  path          = "/"
+  force_destroy = true
+}
+
+resource "aws_iam_access_key" "iam_user_key" {
+  depends_on = [
+    aws_iam_user.iam_user
+  ]
+  user = var.iam_user_name
+}
+
+resource "aws_iam_policy_attachment" "policy_attachment" {
+  name       = "${var.iam_user_name}-policy-attachment"
+  users      = [aws_iam_user.iam_user.name]
+  policy_arn = aws_iam_policy.policy.arn
+}

--- a/primary-site/aws/modules/iam/main.tf
+++ b/primary-site/aws/modules/iam/main.tf
@@ -37,7 +37,6 @@ resource "aws_iam_policy" "policy" {
   policy = data.aws_iam_policy_document.policy_document.json
 }
 
-# Admin user for Terraform to access this sub-org
 resource "aws_iam_user" "iam_user" {
   name          = var.iam_user_name
   path          = "/"

--- a/primary-site/aws/modules/iam/outputs.tf
+++ b/primary-site/aws/modules/iam/outputs.tf
@@ -1,0 +1,11 @@
+output "iam_user_access_id" {
+  value       = aws_iam_access_key.iam_user_key.id
+  description = "IAM user with programmatic access to read/write S3 buckets with"
+  sensitive   = true
+}
+
+output "iam_user_secret_key" {
+  value       = aws_iam_access_key.iam_user_key.secret
+  description = "IAM user with programmatic access to read/write S3 buckets with"
+  sensitive   = true
+}

--- a/primary-site/aws/modules/iam/variables.tf
+++ b/primary-site/aws/modules/iam/variables.tf
@@ -1,0 +1,14 @@
+variable "lake_bucket_arn" {
+  type        = string
+  description = "ARN of the lake S3 bucket"
+}
+
+variable "inbox_bucket_arn" {
+  type        = string
+  description = "ARN of the inbox S3 bucket"
+}
+
+variable "iam_user_name" {
+  type        = string
+  description = "Name of the IAM user to be created"
+}

--- a/primary-site/aws/modules/s3/main.tf
+++ b/primary-site/aws/modules/s3/main.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "bucket" {
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "private"
+}

--- a/primary-site/aws/modules/s3/outputs.tf
+++ b/primary-site/aws/modules/s3/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_name" {
+  value       = aws_s3_bucket.bucket.bucket
+  description = "Name of the S3 bucket created (will be the same as the input variable)"
+}
+
+output "bucket_id" {
+  value       = aws_s3_bucket.bucket.id
+  description = "ID of the S3 bucket created"
+}
+
+output "bucket_arn" {
+  value       = aws_s3_bucket.bucket.arn
+  description = "ARN of the S3 bucket created"
+}

--- a/primary-site/aws/modules/s3/variables.tf
+++ b/primary-site/aws/modules/s3/variables.tf
@@ -1,0 +1,4 @@
+variable "bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket"
+}

--- a/primary-site/aws/modules/sns/main.tf
+++ b/primary-site/aws/modules/sns/main.tf
@@ -1,0 +1,75 @@
+resource "aws_sns_topic" "topic" {
+  name = var.topic_name
+  delivery_policy = jsonencode({
+    "http" : {
+      "defaultHealthyRetryPolicy" : {
+        "minDelayTarget" : 20,
+        "maxDelayTarget" : 20,
+        "numRetries" : 5,
+        "numMaxDelayRetries" : 0,
+        "numNoDelayRetries" : 0,
+        "numMinDelayRetries" : 0,
+        "backoffFunction" : "linear"
+      },
+      "disableSubscriptionOverrides" : false,
+      "defaultThrottlePolicy" : {
+        "maxReceivesPerSecond" : 1
+      }
+    }
+  })
+}
+
+data "aws_iam_policy_document" "sns_topic_policy" {
+  policy_id = "__default_policy_ID"
+
+  statement {
+    actions = [
+      "SNS:Publish",
+    ]
+
+    condition {
+      test     = "ArnLike"
+      variable = "AWS:SourceArn"
+
+      values = [
+        var.bucket_arn
+      ]
+    }
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+
+    resources = [
+      aws_sns_topic.topic.arn,
+    ]
+
+    sid = "__default_statement_ID"
+  }
+}
+
+resource "aws_sns_topic_policy" "default" {
+  arn    = aws_sns_topic.topic.arn
+  policy = data.aws_iam_policy_document.sns_topic_policy.json
+}
+
+resource "aws_sns_topic_subscription" "webhook" {
+  topic_arn = aws_sns_topic.topic.arn
+  protocol  = "https"
+  endpoint  = var.inbox_notification_endpoint
+}
+
+resource "aws_s3_bucket_notification" "s3_notification" {
+  bucket = var.bucket_id
+
+  topic {
+    topic_arn = aws_sns_topic.topic.arn
+
+    events = [
+      "s3:ObjectCreated:*",
+    ]
+  }
+}

--- a/primary-site/aws/modules/sns/variables.tf
+++ b/primary-site/aws/modules/sns/variables.tf
@@ -1,0 +1,19 @@
+variable "topic_name" {
+  type        = string
+  description = "Name of the SNS topic"
+}
+
+variable "bucket_id" {
+  type        = string
+  description = "ID of the S3 bucket that will send ObjectCreated events to the topic"
+}
+
+variable "bucket_arn" {
+  type        = string
+  description = "ARN of the S3 bucket that will send ObjectCreated events to the topic"
+}
+
+variable "inbox_notification_endpoint" {
+  type        = string
+  description = "https endpoint to call on file upload"
+}

--- a/primary-site/aws/provider.tf
+++ b/primary-site/aws/provider.tf
@@ -1,0 +1,9 @@
+# Store Terraform state in S3 (NOTE we don't use DynamoDB so there's no locking information)
+terraform {
+  required_version = ">= 1.3.2"
+  backend "s3" {}
+}
+
+provider "aws" {
+  region  = "us-east-1"
+}

--- a/primary-site/aws/terraform.tfvars-example
+++ b/primary-site/aws/terraform.tfvars-example
@@ -3,5 +3,5 @@ lake_bucket_name  = "org-slug-lake-bucket"
 vpc_name          = "org-slug-vpc"
 eks_cluster_name  = "org-slug-cluster"
 
-inbox_notification_endpoint = "https://29b2-82-28-66-178.eu.ngrok.io"
+inbox_notification_endpoint = "https://api.foxglove.party/endpoints/inbox-notifications?token=XXXXXXXXXEXAMPLE"
 primarysite_iam_user_name = "org-slug-primarysite-user"

--- a/primary-site/aws/terraform.tfvars-example
+++ b/primary-site/aws/terraform.tfvars-example
@@ -1,7 +1,7 @@
 inbox_bucket_name = "org-slug-inbox-bucket"
 lake_bucket_name  = "org-slug-lake-bucket"
 vpc_name          = "org-slug-vpc"
-cluster_name      = "org-slug-cluster"
+eks_cluster_name  = "org-slug-cluster"
 
 inbox_notification_endpoint = "https://29b2-82-28-66-178.eu.ngrok.io"
 primarysite_iam_user_name = "org-slug-primarysite-user"

--- a/primary-site/aws/terraform.tfvars-example
+++ b/primary-site/aws/terraform.tfvars-example
@@ -1,0 +1,7 @@
+inbox_bucket_name = "org-slug-inbox-bucket"
+lake_bucket_name  = "org-slug-lake-bucket"
+vpc_name          = "org-slug-vpc"
+cluster_name      = "org-slug-cluster"
+
+inbox_notification_endpoint = "https://29b2-82-28-66-178.eu.ngrok.io"
+primarysite_iam_user_name = "org-slug-primarysite-user"

--- a/primary-site/aws/variables.tf
+++ b/primary-site/aws/variables.tf
@@ -17,3 +17,13 @@ variable "primarysite_iam_user_name" {
   type        = string
   description = "Name of the primary site's IAM user with programmatic access"
 }
+
+variable "vpc_name" {
+  type        = string
+  description = "Name of the VPC"
+}
+
+variable "eks_cluster_name" {
+  type        = string
+  description = "Name of the EKS cluster"
+}

--- a/primary-site/aws/variables.tf
+++ b/primary-site/aws/variables.tf
@@ -1,0 +1,19 @@
+variable "inbox_bucket_name" {
+  type        = string
+  description = "S3 bucket to be used as inbox"
+}
+
+variable "lake_bucket_name" {
+  type        = string
+  description = "S3 bucket to be used as lake"
+}
+
+variable "inbox_notification_endpoint" {
+  type        = string
+  description = "https endpoint to call on file upload"
+}
+
+variable "primarysite_iam_user_name" {
+  type        = string
+  description = "Name of the primary site's IAM user with programmatic access"
+}


### PR DESCRIPTION
**Public-Facing Changes**

Best place to start the review is probably the readme: https://github.com/foxglove/terraform-examples/tree/wimagguc/fg-883-aws-terraform-example/primary-site/aws

This is a basic Terraform template that deploys a working primary site deployment:

- [x] S3 lake and inbox buckets
- [x] SNS topic & https subscription to be sent to the inbox notification endpoint
- [x] IAM user with programmatic access, to be set up as `cloud-credentials` secret
- [x] VPC
- [x] EKS cluster with managed node group & Fargate profiles
- [x] Readme: load balancer controller config, logging & coredns

It leaves out some of the intricacies of managing a production EKS cluster, for example, we don't create an IAM role to assume to connect to the EKS cluster as the non-creator IAM user. These considerations are all described in the [readme](https://github.com/foxglove/terraform-examples/tree/wimagguc/fg-883-aws-terraform-example/primary-site/aws).
