### PR TITLE
Add a lifecycle rule example to delete incomplete AWS multipart uploads

### DIFF
--- a/primary-site/aws/main.tf
+++ b/primary-site/aws/main.tf
@@ -3,11 +3,15 @@
 module "s3_lake" {
   source      = "./modules/s3"
   bucket_name = var.lake_bucket_name
+
+  abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
 }
 
 module "s3_inbox" {
   source      = "./modules/s3"
   bucket_name = var.inbox_bucket_name
+
+  abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
 }
 
 ## ----- Pubsub -----

--- a/primary-site/aws/modules/s3/main.tf
+++ b/primary-site/aws/modules/s3/main.tf
@@ -6,3 +6,16 @@ resource "aws_s3_bucket_acl" "bucket_acl" {
   bucket = aws_s3_bucket.bucket.id
   acl    = "private"
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "bucket_lifecycle" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    id     = "${var.bucket_name}-delete-incomplete-uploads-rule"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = var.abort_incomplete_multipart_upload_days
+    }
+  }
+}

--- a/primary-site/aws/modules/s3/variables.tf
+++ b/primary-site/aws/modules/s3/variables.tf
@@ -2,3 +2,8 @@ variable "bucket_name" {
   type        = string
   description = "Name of the S3 bucket"
 }
+
+variable "abort_incomplete_multipart_upload_days" {
+  type        = number
+  description = "Number of days a multipart upload needs to be completed within"
+}

--- a/primary-site/aws/terraform.tfvars-example
+++ b/primary-site/aws/terraform.tfvars-example
@@ -3,5 +3,6 @@ lake_bucket_name  = "org-slug-lake-bucket"
 vpc_name          = "org-slug-vpc"
 eks_cluster_name  = "org-slug-cluster"
 
-inbox_notification_endpoint = "https://api.foxglove.party/endpoints/inbox-notifications?token=XXXXXXXXXEXAMPLE"
-primarysite_iam_user_name = "org-slug-primarysite-user"
+inbox_notification_endpoint            = "https://api.foxglove.party/endpoints/inbox-notifications?token=XXXXXXXXXEXAMPLE"
+primarysite_iam_user_name              = "org-slug-primarysite-user"
+abort_incomplete_multipart_upload_days = 5

--- a/primary-site/aws/variables.tf
+++ b/primary-site/aws/variables.tf
@@ -27,3 +27,8 @@ variable "eks_cluster_name" {
   type        = string
   description = "Name of the EKS cluster"
 }
+
+variable "abort_incomplete_multipart_upload_days" {
+  type        = number
+  description = "Number of days a multipart upload needs to be completed within"
+}

--- a/primary-site/gcp/README.md
+++ b/primary-site/gcp/README.md
@@ -68,7 +68,9 @@ You should now be able to run `terraform plan` and `terraform apply`.
   This user has access to read/write both the `inbox` and `lake` buckets.
 
 - `storage`: creates a bucket with private access. This module is used to create the `inbox` and
-  `lake` buckets.
+  `lake` buckets. The lifecycle rule ensures that incomplete multipart uploads are garbage
+  collected - otherwise the uploaded parts would remain in the S3 bucket, occurring charges
+  forever.
 
 - `pubsub`: creates a Pub/Sub topic and dead letter queue with a https subscription, and attaches
   it to a bucket's `OBJECT_FINALIZE` object notifications. Whenever a new object appears


### PR DESCRIPTION
**Public-Facing Changes**

S3 lifecycle rule to delete incomplete multipart upload parts after a set number of days.

**Description**

We can copy large files to S3 buckets using the multipart copy APIs, but if completing the upload fails, the uploaded parts remain in the S3 bucket and we'll [occur charges forever](https://aws.amazon.com/blogs/aws-cloud-financial-management/discovering-and-deleting-incomplete-multipart-uploads-to-lower-amazon-s3-costs/).

The uploaded but not used parts are neither visible on the AWS Console, nor using `aws s3 ls`, but they can be queried using:

```
aws s3api list-multipart-uploads --bucket [BucketName]
```

To test this feature and to create a failed multipart upload, you can call:

```
aws s3api create-multipart-upload --bucket [BucketName] --key [ObjectKey]

// (Record the UploadId from the output)

aws s3api upload-part --bucket [BucketName] --key [ObjectKey] --part-number 1 --body [local/file/path.part1] --upload-id [UploadId]
```

...if you never complete the upload using `aws s3api complete-multipart-upload`, it will appear in the `s3api list-multipart-uploads` query above.
