### PR TITLE
Fix links on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Use the templates under `/primary-site` to create resources for a Foxglove Prima
 
 For more details, see the README for each platform:
 
-* [Amazon AWS](./blob/main/primary-site/aws/README.md)
-* [Google Cloud Platform](./blob/main/primary-site/gcp/README.md)
-* [Microsoft Azure](./blob/main/primary-site/azure/README.md)
+* [Amazon AWS](./primary-site/aws/README.md)
+* [Google Cloud Platform](./primary-site/gcp/README.md)
+* [Microsoft Azure](./primary-site/azure/README.md)


### PR DESCRIPTION
This fixes the linked paths in the Readme, which are currently resolving with `/blob/main/blob/main`.