### PR TITLE
Update links from .party to .dev

### DIFF
--- a/primary-site/aws/README.md
+++ b/primary-site/aws/README.md
@@ -39,7 +39,7 @@ The provider in this Terraform package will pick up the default credentials.
 ### Run Terraform
 
 Configure the variables. Note that some of them you'll find on the Foxglove console's
-[Settings page](https://console.foxglove.party/organization?tab=sites), under the Sites
+[Settings page](https://console.foxglove.dev/organization?tab=sites), under the Sites
 tab.
 
 1. Copy `terraform.tfvars-example` to `terraform.tfvars`

--- a/primary-site/azure/README.md
+++ b/primary-site/azure/README.md
@@ -30,7 +30,7 @@ the [azurerm backend docs](https://developer.hashicorp.com/terraform/language/se
 ### Run Terraform
 
 Configure the variables. Note that some of them you'll find on the Foxglove console's
-[Settings page](https://console.foxglove.party/organization?tab=sites), under the Sites
+[Settings page](https://console.foxglove.dev/organization?tab=sites), under the Sites
 tab.
 
 1. Copy `terraform.tfvars-example` to `terraform.tfvars`

--- a/primary-site/gcp/README.md
+++ b/primary-site/gcp/README.md
@@ -45,7 +45,7 @@ credentials.
 ### Run Terraform
 
 Configure the variables. Note that some of them you'll find on the Foxglove console's
-[Settings page](https://console.foxglove.party/organization?tab=sites), under the Sites
+[Settings page](https://console.foxglove.dev/organization?tab=sites), under the Sites
 tab.
 
 1. Copy `terraform.tfvars-example` to `terraform.tfvars`


### PR DESCRIPTION
Fix a few broken links in the terraform documentation pointing to the wrong domain.