### PR TITLE
Package updates & now including Terraform lock files

### DIFF
--- a/primary-site/aws/main.tf
+++ b/primary-site/aws/main.tf
@@ -31,7 +31,7 @@ data "aws_availability_zones" "available" {}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.14.2"
+  version = "5.0.0"
 
   name = var.vpc_name
 
@@ -67,10 +67,10 @@ module "vpc" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "18.30.2"
+  version = "19.15.3"
 
   cluster_name                    = var.eks_cluster_name
-  cluster_version                 = "1.24"
+  cluster_version                 = "1.27"
   cluster_endpoint_private_access = true
   cluster_endpoint_public_access  = true
 

--- a/primary-site/gcp/main.tf
+++ b/primary-site/gcp/main.tf
@@ -45,7 +45,7 @@ module "iam" {
 
 module "vpc" {
   source       = "terraform-google-modules/network/google"
-  version      = "5.2.0"
+  version      = "7.1.0"
   project_id   = var.gcp_project
   network_name = var.vpc_name
   subnets = [


### PR DESCRIPTION
### Public-Facing Changes

Updated the Terraform modules used in the AWS and GCP examples to their latest versions.

This PR also includes the Terraform lockfile as per [their recommendation](https://developer.hashicorp.com/terraform/language/files/dependency-lock) — not sure why we put them in Gitignore in the first place but hey ho.

Note that there's a deprecation warning in the Terraform AWS EKS module. Nothing for us to do right now, people of the module are aware: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2635

### Testing

Tested with an end-to-end `terraform apply` & `terraform destroy` for both aws & gcp.