### PR TITLE
Update SNS Topic Delivery Policy

### DIFF
--- a/primary-site/aws/modules/sns/main.tf
+++ b/primary-site/aws/modules/sns/main.tf
@@ -3,17 +3,7 @@ resource "aws_sns_topic" "topic" {
   delivery_policy = jsonencode({
     "http" : {
       "defaultHealthyRetryPolicy" : {
-        "minDelayTarget" : 20,
-        "maxDelayTarget" : 20,
-        "numRetries" : 5,
-        "numMaxDelayRetries" : 0,
-        "numNoDelayRetries" : 0,
-        "numMinDelayRetries" : 0,
-        "backoffFunction" : "linear"
-      },
-      "disableSubscriptionOverrides" : false,
-      "defaultThrottlePolicy" : {
-        "maxReceivesPerSecond" : 1
+        "numRetries" : 100,
       }
     }
   })


### PR DESCRIPTION
### Public-Facing Changes

We inadvertently limited SNS message deliveries to 1 per second. This removes that limit (the default is unlimited) as well as other values that are not necessary to set. The only change from default is to up the number of retries to the maximum of 100.
