### PR TITLE
AWS example now configures a DLQ for inbox notifications

### DIFF
--- a/primary-site/aws/modules/s3/main.tf
+++ b/primary-site/aws/modules/s3/main.tf
@@ -2,11 +2,6 @@ resource "aws_s3_bucket" "bucket" {
   bucket = var.bucket_name
 }
 
-resource "aws_s3_bucket_acl" "bucket_acl" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "bucket_lifecycle" {
   bucket = aws_s3_bucket.bucket.id
 

--- a/primary-site/aws/modules/sns/main.tf
+++ b/primary-site/aws/modules/sns/main.tf
@@ -1,9 +1,15 @@
+resource "aws_sqs_queue" "dlq" {
+  name = "${var.topic_name}-sqs-dlq"
+}
+
 resource "aws_sns_topic" "topic" {
   name = var.topic_name
   delivery_policy = jsonencode({
     "http" : {
       "defaultHealthyRetryPolicy" : {
         "numRetries" : 100,
+        "minDelayTarget" : 20, // In seconds; default is 20
+        "maxDelayTarget" : 20, // In seconds; default is 20
       }
     }
   })
@@ -46,10 +52,46 @@ resource "aws_sns_topic_policy" "default" {
   policy = data.aws_iam_policy_document.sns_topic_policy.json
 }
 
+data "aws_iam_policy_document" "sqs_dlq_policy" {
+  policy_id = "__default_policy_ID"
+
+  statement {
+    actions = [
+      "SQS:SendMessage"
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["sns.amazonaws.com"]
+    }
+
+    resources = [
+      aws_sqs_queue.dlq.arn,
+    ]
+
+    condition {
+      test     = "ArnEquals"
+      values   = [aws_sns_topic.topic.arn]
+      variable = "aws:SourceArn"
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "allow_publish_from_sns" {
+  queue_url = aws_sqs_queue.dlq.id
+  policy = data.aws_iam_policy_document.sqs_dlq_policy.json
+}
+
 resource "aws_sns_topic_subscription" "webhook" {
   topic_arn = aws_sns_topic.topic.arn
   protocol  = "https"
   endpoint  = var.inbox_notification_endpoint
+
+  redrive_policy = jsonencode({
+    "deadLetterTargetArn" : aws_sqs_queue.dlq.arn
+  })
 }
 
 resource "aws_s3_bucket_notification" "s3_notification" {


### PR DESCRIPTION
### Public-Facing Changes

The SNS subscription now configures a dead letter queue, so messages are not dropped to the ground in case Console is unavailable.

Tested end-to-end with the latest console & data-platform. Indeed, after an object lands in the bucket, SNS will attempt to deliver the notification max `numRetries`(+1) times:

```
{
  "Type" : "Notification",
  "MessageId" : "7d70475b-5c8a-5bd4-9cbe-1ad56997a6fd",
  "TopicArn" : "arn:aws:sns:us-east-1:096363264652:org-slug-inbox-bucket-delete-me-sns-topic",
  "Subject" : "Amazon S3 Notification",
  "Message" : "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\", ... \"eTag\":\"8964da5a74d6afdac379cc72575fef79\",\"sequencer\":\"00651432DCA7EF4799\"}}}]}",
...
```

...and after we run out of retries, the message appears in SQS as expected:

```
$ aws sqs receive-message --queue-url 'https://sqs.us-east-1.amazonaws.com/096363264652/org-slug-inbox-bucket-delete-me-sns-topic-sqs-dlq'

{
    "Messages": [
        {
            "Body": "{\n  \"Type\" : \"Notification\",\n  \"MessageId\" : \"7d70475b-5c8a-5bd4-9cbe-1ad56997a6fd\",\n  ...\\\"eTag\\\":\\\"8964da5a74d6afdac379cc72575fef79\\\",\\\"sequencer\\\":\\\"00651432DCA7EF4799\\\"}}}]}\",\n 
...
```