### PR TITLE
Fix: deprecated terraform property for the azure example

### DIFF
--- a/primary-site/azure/modules/iam/main.tf
+++ b/primary-site/azure/modules/iam/main.tf
@@ -8,7 +8,7 @@ resource "azuread_application" "primary_site" {
 }
 
 resource "azuread_service_principal" "iam_principal" {
-  application_id = azuread_application.primary_site.application_id
+  client_id      = azuread_application.primary_site.client_id
   owners         = [data.azuread_client_config.current.object_id]
 }
 

--- a/primary-site/azure/modules/iam/outputs.tf
+++ b/primary-site/azure/modules/iam/outputs.tf
@@ -4,8 +4,8 @@ output "tenant_id" {
 }
 
 output "client_id" {
-  value       = azuread_application.primary_site.application_id
-  description = "Echoes the `application_id` output value"
+  value       = azuread_application.primary_site.client_id
+  description = "Echoes the `client_id` output value"
 }
 
 output "client_secret" {


### PR DESCRIPTION
### Changelog
Azure had deprecated one of the TF properties. Changed it to use the new value. 

### Docs

Not required 

### Description



