### PR TITLE
AWS: grant stream service access to inbox

### DIFF
--- a/primary-site/aws/modules/iam/stream-service.tf
+++ b/primary-site/aws/modules/iam/stream-service.tf
@@ -12,9 +12,12 @@ data "aws_iam_policy_document" "stream_service_policy_document" {
       "s3:GetObject",
       "s3:GetObjectVersion"
     ]
+    # Read access to the inbox is provided to serve quarantined files
     resources = [
       var.lake_bucket_arn,
-      "${var.lake_bucket_arn}/*"
+      "${var.lake_bucket_arn}/*",
+      var.inbox_bucket_arn,
+      "${var.inbox_bucket_arn}/*",
     ]
     effect = "Allow"
   }


### PR DESCRIPTION
### Changelog

AWS: grant stream service access to inbox

### Docs

None. Our existing documentation [does not go into this level of detail](https://docs.foxglove.dev/docs/primary-sites/self-hosting/configure-cloud-credentials/#service-accounts), instead relying on examples.

### Description

The stream service should have read access to the inbox in order to serve quarantined files back to a user, so that they can re-attempt import. This is an upcoming feature of the API and stream service.

The examples for Azure and GCP do not provide granular IAM today, and should not need changing.