### PR TITLE
Update examples to include rules for deleting failed pending imports

### DIFF
--- a/primary-site/aws/modules/iam/inbox-listener.tf
+++ b/primary-site/aws/modules/iam/inbox-listener.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "inbox_listener_policy_document" {
 }
 
 resource "aws_iam_policy" "inbox_listener_policy" {
-  name = "${var.eks_foxglove_namespace}-inbox-listener-sa-policy"
+  name   = "${var.eks_foxglove_namespace}-inbox-listener-sa-policy"
   path   = "/"
   policy = data.aws_iam_policy_document.inbox_listener_policy_document.json
 }

--- a/primary-site/aws/modules/iam/stream-service.tf
+++ b/primary-site/aws/modules/iam/stream-service.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "stream_service_policy_document" {
       "s3:ListBucket"
     ]
     resources = [var.lake_bucket_arn]
-    effect = "Allow"
+    effect    = "Allow"
   }
   statement {
     actions = [
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "stream_service_policy_document" {
 }
 
 resource "aws_iam_policy" "stream_service_policy" {
-  name = "${var.eks_foxglove_namespace}-stream-service-sa-policy"
+  name   = "${var.eks_foxglove_namespace}-stream-service-sa-policy"
   path   = "/"
   policy = data.aws_iam_policy_document.stream_service_policy_document.json
 }

--- a/primary-site/aws/modules/s3/main.tf
+++ b/primary-site/aws/modules/s3/main.tf
@@ -9,6 +9,12 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket_lifecycle" {
     id     = "${var.bucket_name}-delete-incomplete-uploads-rule"
     status = "Enabled"
 
+    # At least one filter rule is required by Terraform.
+    # Default to an empty prefix to include everything.
+    filter {
+      prefix = ""
+    }
+
     abort_incomplete_multipart_upload {
       days_after_initiation = var.abort_incomplete_multipart_upload_days
     }

--- a/primary-site/aws/modules/s3/main.tf
+++ b/primary-site/aws/modules/s3/main.tf
@@ -13,4 +13,22 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket_lifecycle" {
       days_after_initiation = var.abort_incomplete_multipart_upload_days
     }
   }
+
+  # Failed imports are cleaned up in the control plane after a year, this rule will
+  # remove their backing objects the following day.
+  #
+  # This rule is only required for the inbox bucket, but it will have no impact on
+  # the lake bucket so it is fine here.
+  rule {
+    id     = "${var.bucket_name}-delete-old-quarantined-files"
+    status = "Enabled"
+
+    filter {
+      prefix = "_quarantine/"
+    }
+
+    expiration {
+      days = 366
+    }
+  }
 }

--- a/primary-site/aws/modules/sns/main.tf
+++ b/primary-site/aws/modules/sns/main.tf
@@ -81,7 +81,7 @@ data "aws_iam_policy_document" "sqs_dlq_policy" {
 
 resource "aws_sqs_queue_policy" "allow_publish_from_sns" {
   queue_url = aws_sqs_queue.dlq.id
-  policy = data.aws_iam_policy_document.sqs_dlq_policy.json
+  policy    = data.aws_iam_policy_document.sqs_dlq_policy.json
 }
 
 resource "aws_sns_topic_subscription" "webhook" {

--- a/primary-site/aws/provider.tf
+++ b/primary-site/aws/provider.tf
@@ -5,5 +5,5 @@ terraform {
 }
 
 provider "aws" {
-  region  = "us-east-1"
+  region = "us-east-1"
 }

--- a/primary-site/azure/modules/iam/main.tf
+++ b/primary-site/azure/modules/iam/main.tf
@@ -8,8 +8,8 @@ resource "azuread_application" "primary_site" {
 }
 
 resource "azuread_service_principal" "iam_principal" {
-  client_id      = azuread_application.primary_site.client_id
-  owners         = [data.azuread_client_config.current.object_id]
+  client_id = azuread_application.primary_site.client_id
+  owners    = [data.azuread_client_config.current.object_id]
 }
 
 resource "azuread_service_principal_password" "iam_principal" {

--- a/primary-site/gcp/modules/pubsub/main.tf
+++ b/primary-site/gcp/modules/pubsub/main.tf
@@ -14,13 +14,13 @@ module "inbox_notifications" {
   topic      = "${var.bucket_name}-notifications"
   push_subscriptions = [
     {
-      name                  = "${var.bucket_name}-push-sub"
-      push_endpoint         = var.inbox_notification_endpoint
+      name          = "${var.bucket_name}-push-sub"
+      push_endpoint = var.inbox_notification_endpoint
 
       # To avoid the error where the push_subscriptions "for_each" map includes keys derived
       # from resource attributes that cannot be determined until apply, we "hard-code" the dead
       # letter topic name here. This is why `depends_on` is needed above.
-      dead_letter_topic     = "projects/${var.gcp_project}/topics/${var.bucket_name}-notifications-dlq"
+      dead_letter_topic = "projects/${var.gcp_project}/topics/${var.bucket_name}-notifications-dlq"
 
       x-goog-version        = "v1"
       ack_deadline_seconds  = 600

--- a/primary-site/gcp/modules/storage/main.tf
+++ b/primary-site/gcp/modules/storage/main.tf
@@ -27,8 +27,8 @@ resource "google_storage_bucket" "bucket" {
     }
   }
 
-  // Deleting `tmp/` prefixed objects is required for the lake bucket only, but has
-  // no impact on the inbox bucket
+  # Deleting `tmp/` prefixed objects is required for the lake bucket only, but has
+  # no impact on the inbox bucket
   lifecycle_rule {
     action {
       type = "Delete"
@@ -37,6 +37,22 @@ resource "google_storage_bucket" "bucket" {
       with_state     = "LIVE"
       matches_prefix = ["tmp/"]
       age            = 1
+    }
+  }
+
+  # Failed imports are cleaned up in the control plane after a year, this rule will
+  # remove their backing objects the following day.
+  #
+  # This rule is only required for the inbox bucket to the inbox bucket, but will
+  # have no impact on the lake bucket.
+  lifecycle_rule {
+    action = {
+      type = "Delete"
+    }
+    condition {
+      with_state     = "LIVE"
+      matches_prefix = ["_quarantine/"]
+      age            = 366
     }
   }
 }


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

None

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

Since pending imports are deleted after a year, this adds rules to each of the clouds to make sure quarantined files are cleaned up after a year.

- [x] test against the three clouds

