### PR TITLE
new input vars: cluster version and aws region; output: oidc, vpc arns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 terraform.tfstate
 terraform.tfstate.backup
 terraform.tfvars
+terraform.*.tfvars
 backend.tfvars
+backend.*.tfvars

--- a/primary-site/aws/main.tf
+++ b/primary-site/aws/main.tf
@@ -70,7 +70,7 @@ module "eks" {
   version = "19.15.3"
 
   cluster_name                    = var.eks_cluster_name
-  cluster_version                 = "1.27"
+  cluster_version                 = var.eks_cluster_version
   cluster_endpoint_private_access = true
   cluster_endpoint_public_access  = true
 

--- a/primary-site/aws/output.tf
+++ b/primary-site/aws/output.tf
@@ -1,0 +1,9 @@
+output "eks_oidc_provider_arn" {
+  value       = module.eks.oidc_provider_arn
+  description = "ARN of the EKS OIDC provider"
+}
+
+output "eks_vpc_arn" {
+  value       = module.vpc.vpc_arn
+  description = "VPC ID of the EKS cluster"
+}

--- a/primary-site/aws/provider.tf
+++ b/primary-site/aws/provider.tf
@@ -5,5 +5,5 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region = var.aws_region
 }

--- a/primary-site/aws/terraform.tfvars-example
+++ b/primary-site/aws/terraform.tfvars-example
@@ -1,7 +1,9 @@
+aws_region        = "us-east-1"
 inbox_bucket_name = "org-slug-inbox-bucket"
 lake_bucket_name  = "org-slug-lake-bucket"
 vpc_name          = "org-slug-vpc"
 eks_cluster_name  = "org-slug-cluster"
+eks_cluster_version   = "1.27"
 
 inbox_notification_endpoint            = "https://api.foxglove.dev/endpoints/inbox-notifications?token=XXXXXXXXXEXAMPLE"
 primarysite_iam_user_name              = "org-slug-primarysite-user"

--- a/primary-site/aws/variables.tf
+++ b/primary-site/aws/variables.tf
@@ -32,3 +32,15 @@ variable "abort_incomplete_multipart_upload_days" {
   type        = number
   description = "Number of days a multipart upload needs to be completed within"
 }
+
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "eks_cluster_version" {
+  description = "EKS cluster version"
+  type        = string
+  default     = "1.27"
+}


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

This PR adds 2 input variables to allow specifying the EKS cluster version and the AWS region where it should be deployed.
It also outputs the EKS cluster's OIDC ARN and the cluster's VPC ARN, so that dependent Terraform configs can build upon them, for example to allow Service Account <-> IAM Role integration in AWS LBC, or to restrict access in IAM policies.

### Testing done
- Created infrastructure using this revision, passing a custom aws-region, and eks_cluster_version = 1.32
- Verified that the cluster is indeed created in the expected region with the expected version
- Created additional infrastructure using a separate Terraform stack, configured to read the output from terraform-examples.
- Verified that the output is readable as expected
- Completed foxglove installation
- Verified that a local agent can upload files to foxglove in self-managed mode
- Verified that such files can be visualized in the UI, and that they are retrieved from the self-managed endpoint


