### PR TITLE
docs: add missing step in gcp instructions

### DIFF
--- a/primary-site/gcp/README.md
+++ b/primary-site/gcp/README.md
@@ -20,6 +20,7 @@ Terraform needs a GCS project and a service account with project owner permissio
 To add a new service account with a private key:
 
 - Select `IAM & Admin` and then `Service Accounts`
+- Select `Create service account`
 - In `Grant this service account access to the project` select `Owner` basic role
 - Open the `keys` tab, add a new key and download it as a JSON
 


### PR DESCRIPTION
### Changelog
Update GCP documentation to make the service account creation flow more complete. 

### Description
While going through the terraform README linked from the [primary site installation](http://docs.foxglove.dev/docs/data/primary-sites/installation#prerequisites) documentation I noticed that there was a step missing in the service account creation flow. 