### PR TITLE
Update GCP instructions for clarity

### DIFF
--- a/primary-site/gcp/README.md
+++ b/primary-site/gcp/README.md
@@ -57,16 +57,14 @@ credentials.
 First, configure the Terraform backend to store state in GCS:
 
 1. Copy `backend.tfvars-example` to `backend.tfvars`
-2. Update the following variables in `backend.tfvars`:
-   - `bucket`: The name of the GCS bucket you created in the "Create GCS bucket for Terraform state" step for storing Terraform state
-   - `prefix`: The path/prefix for your Terraform state file (e.g., `primarysite/my-environment`)
+2. Update the variables in `backend.tfvars`:
 
 3. Initialize Terraform with the backend configuration:
    ```
    terraform init --backend-config backend.tfvars
    ```
 
-   After initialization, your GCS bucket will have the following structure:
+   After initialization, your GCS bucket will have a structure similar to this:
    ```
    <bucket>
    |--primarysite (Directory)
@@ -80,17 +78,7 @@ Next, configure the main Terraform variables. Note that some of them you'll find
 [Settings page](https://app.foxglove.dev/~/settings/sites), under the Sites tab.
 
 1. Copy `terraform.tfvars-example` to `terraform.tfvars`
-2. Update the following variables in `terraform.tfvars`:
-   - `gcp_project`: Your GCP project ID
-   - `gcp_region`: The GCP region where resources will be created (e.g., `us-east1`)
-   - `vpc_name`: Name for the VPC (e.g., `org-slug-vpc`)
-   - `cluster_name`: Name for the GKE cluster (e.g., `org-slug-cluster`)
-   - `inbox_bucket_name`: Name for the inbox storage bucket (e.g., `org-slug-inbox-bucket`)
-   - `lake_bucket_name`: Name for the lake storage bucket (e.g., `org-slug-lake-bucket`)
-   - `bucket_delete_days_since_noncurrent_time`: Days to retain non-current object versions (default: 14)
-   - `bucket_delete_num_newer_version`: Number of newer versions to retain (default: 3)
-   - `inbox_notification_endpoint`: Webhook endpoint from the Foxglove site settings (e.g, `https://api.foxglove.dev/endpoints/inbox-notifications?token=fox_snt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`)
-   - `primarysite_iam_user_name`: Name for the IAM service account (e.g., `org-slug-primarysite-user`)
+2. Update the variables in `terraform.tfvars`:
 
 ### Deploy Resources
 

--- a/primary-site/gcp/README.md
+++ b/primary-site/gcp/README.md
@@ -27,7 +27,7 @@ To add a new service account with a private key:
 
 ### Create GCS bucket for Terraform state
 
-It's best practice to store the Terraform state in GCS's cloud storage. This will be
+It's best practice to store the Terraform state in GCP's cloud storage. This will be
 used to store the `tfstate` in the cloud, rather than keeping them locally.
 
 To create a state bucket:

--- a/primary-site/gcp/README.md
+++ b/primary-site/gcp/README.md
@@ -13,20 +13,29 @@ inbox and lake buckets.
 
 ## Getting started
 
-### Create resources for the Terraform provider
+### Create service account for Terraform provider
 
-Terraform needs a GCS project and a service account with project owner permissions.
+Terraform needs a GCP project and a service account with project owner permissions.
 
 To add a new service account with a private key:
 
 - Select `IAM & Admin` and then `Service Accounts`
 - Select `Create service account`
+- Give it a descriptive name (e.g., `terraform-admin` or `project-terraform-sa`) - note that this is separate from the IAM username `primarysite_iam_user_name` you'll configure later in `terraform.tfvars`
 - In `Grant this service account access to the project` select `Owner` basic role
 - Open the `keys` tab, add a new key and download it as a JSON
 
-It's also best practice to store the Terraform state in GCS's cloud storage. This will be
-used to store the `tfstate` in the cloud, rather than keeping them locally. Create a bucket,
-and make sure to block all public access (the tfstate will contain secrets).
+### Create GCS bucket for Terraform state
+
+It's best practice to store the Terraform state in GCS's cloud storage. This will be
+used to store the `tfstate` in the cloud, rather than keeping them locally.
+
+To create a state bucket:
+
+- Go to `Cloud Storage` and create a new bucket
+- Choose a unique name (e.g., `terraform-state-fg-myproject`)
+- Make sure to block all public access (the tfstate will contain secrets)
+- Note the bucket name - you'll need it for the `backend.tfvars` configuration
 
 ### Use these credentials
 
@@ -43,21 +52,54 @@ gcloud auth application-default login
 Whichever method you choose, the provider in the Terraform package will pick up the default
 credentials.
 
-### Run Terraform
+### Configure Terraform Backend
 
-Configure the variables. Note that some of them you'll find on the Foxglove
-[Settings page](https://app.foxglove.dev/~/settings/sites), under the Sites
-tab.
+First, configure the Terraform backend to store state in GCS:
+
+1. Copy `backend.tfvars-example` to `backend.tfvars`
+2. Update the following variables in `backend.tfvars`:
+   - `bucket`: The name of the GCS bucket you created in the "Create GCS bucket for Terraform state" step for storing Terraform state
+   - `prefix`: The path/prefix for your Terraform state file (e.g., `primarysite/my-environment`)
+
+3. Initialize Terraform with the backend configuration:
+   ```
+   terraform init --backend-config backend.tfvars
+   ```
+
+   After initialization, your GCS bucket will have the following structure:
+   ```
+   <bucket>
+   |--primarysite (Directory)
+     |--my-environment (Directory)
+       |--default.tfstate (File)
+   ```
+
+### Configure Terraform Variables
+
+Next, configure the main Terraform variables. Note that some of them you'll find on the Foxglove
+[Settings page](https://app.foxglove.dev/~/settings/sites), under the Sites tab.
 
 1. Copy `terraform.tfvars-example` to `terraform.tfvars`
-2. Use the `inbox_notification_endpoint` variable from the Foxglove site settings.
-3. Change the other variables as needed
-4. Copy `backend.tfvars-example` to `backend.tfvars`
-5. Set the bucket name and region to what was created in the "Getting started" step; key can
-   be any object key.
-6. Run `terraform init --backend-config backend.tfvars`
+2. Update the following variables in `terraform.tfvars`:
+   - `gcp_project`: Your GCP project ID
+   - `gcp_region`: The GCP region where resources will be created (e.g., `us-east1`)
+   - `vpc_name`: Name for the VPC (e.g., `org-slug-vpc`)
+   - `cluster_name`: Name for the GKE cluster (e.g., `org-slug-cluster`)
+   - `inbox_bucket_name`: Name for the inbox storage bucket (e.g., `org-slug-inbox-bucket`)
+   - `lake_bucket_name`: Name for the lake storage bucket (e.g., `org-slug-lake-bucket`)
+   - `bucket_delete_days_since_noncurrent_time`: Days to retain non-current object versions (default: 14)
+   - `bucket_delete_num_newer_version`: Number of newer versions to retain (default: 3)
+   - `inbox_notification_endpoint`: Webhook endpoint from the Foxglove site settings (e.g, `https://api.foxglove.dev/endpoints/inbox-notifications?token=fox_snt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`)
+   - `primarysite_iam_user_name`: Name for the IAM service account (e.g., `org-slug-primarysite-user`)
 
-You should now be able to run `terraform plan` and `terraform apply`.
+### Deploy Resources
+
+Once both configuration files are set up, you can deploy the resources:
+
+```
+terraform plan
+terraform apply
+```
 
 ## Modules
 

--- a/primary-site/gcp/backend.tfvars-example
+++ b/primary-site/gcp/backend.tfvars-example
@@ -1,2 +1,2 @@
-bucket = "terraform-state-fg-CHANGEME"
-prefix = "primarysite/my-environment"
+bucket = "terraform-state-fg-CHANGEME"  # The name of the GCS bucket you created in the "Create GCS bucket for Terraform state" step for storing Terraform state
+prefix = "primarysite/my-environment"  # The path/prefix for your Terraform state file (e.g., `primarysite/my-environment`)

--- a/primary-site/gcp/backend.tfvars-example
+++ b/primary-site/gcp/backend.tfvars-example
@@ -1,3 +1,2 @@
 bucket = "terraform-state-fg-CHANGEME"
-prefix = "primarysite/CHANGEME/terraform.tfstate"
-
+prefix = "primarysite/my-environment"

--- a/primary-site/gcp/terraform.tfvars-example
+++ b/primary-site/gcp/terraform.tfvars-example
@@ -1,12 +1,12 @@
-gcp_project  = "my-project-id"
-gcp_region   = "us-west2"
-vpc_name     = "org-slug-vpc"
-cluster_name = "org-slug-cluster"
+gcp_project  = "my-project-id"  # Your GCP project ID
+gcp_region   = "us-west2"  # The GCP region where resources will be created
+vpc_name     = "org-slug-vpc"  # Name for the VPC
+cluster_name = "org-slug-cluster"  # Name for the GKE cluster
 
-inbox_bucket_name                        = "org-slug-inbox-bucket"
-lake_bucket_name                         = "org-slug-lake-bucket"
-bucket_delete_days_since_noncurrent_time = 14
-bucket_delete_num_newer_version          = 3
+inbox_bucket_name                        = "org-slug-inbox-bucket"  # Name for the inbox storage bucket
+lake_bucket_name                         = "org-slug-lake-bucket"  # Name for the lake storage bucket
+bucket_delete_days_since_noncurrent_time = 14  # Days to retain non-current object versions
+bucket_delete_num_newer_version          = 3  # Number of newer versions to retain (default: 3)
 
-inbox_notification_endpoint = "https://api.foxglove.dev/endpoints/inbox-notifications?token=XXXXXXXXXEXAMPLE"
-primarysite_iam_user_name   = "org-slug-primarysite-user"
+inbox_notification_endpoint = "https://api.foxglove.dev/endpoints/inbox-notifications?token=XXXXXXXXXEXAMPLE"  # Webhook endpoint from the Foxglove site settings
+primarysite_iam_user_name   = "org-slug-primarysite-user"  # Name for the IAM service account


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

Update GCP documentation to make steps more discrete and variables more clear

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

The existing instructions could be confusing to users unfamiliar with Terraform and GCP.

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

Instructions mixed together steps for creating a service account and a GCS backend bucket as well as configuring the backend and main Terraform variable files. 

</td><td>

<!--after content goes here-->

Instructions for creating a GCP Service account are separated from instructions for creating a backend GCS bucket.
Instructions break out Terraform steps into backend and primary discrete steps and explain configuration variables for both files in more detail. 

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

