### PR TITLE
Fix aws examples

### DIFF
--- a/primary-site/aws/main.tf
+++ b/primary-site/aws/main.tf
@@ -38,7 +38,8 @@ module "vpc" {
   # EKS VPC and subnet requirements and considerations
   # https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html
   cidr            = "10.0.0.0/16"
-  azs             = slice(data.aws_availability_zones.available.names, 0, 3)
+  # azs             = slice(data.aws_availability_zones.available.names, 0, 3)
+  azs = data.aws_availability_zones.available.names
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 

--- a/primary-site/aws/modules/iam/garbage-collector.tf
+++ b/primary-site/aws/modules/iam/garbage-collector.tf
@@ -1,6 +1,7 @@
 module "eks_garbage_collector_sa_role" {
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-
+  version = "5.60.0"
+  
   role_name = "${var.eks_foxglove_namespace}-garbage-collector-sa-role"
 
   oidc_providers = {

--- a/primary-site/aws/modules/iam/inbox-listener.tf
+++ b/primary-site/aws/modules/iam/inbox-listener.tf
@@ -39,7 +39,8 @@ resource "aws_iam_policy" "inbox_listener_policy" {
 
 module "eks_inbox_listener_sa_role" {
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-
+  version = "5.60.0"
+  
   role_name = "${var.eks_foxglove_namespace}-inbox-listener-sa-role"
 
   oidc_providers = {

--- a/primary-site/aws/modules/iam/stream-service.tf
+++ b/primary-site/aws/modules/iam/stream-service.tf
@@ -31,6 +31,7 @@ resource "aws_iam_policy" "stream_service_policy" {
 
 module "eks_stream_service_sa_role" {
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.60.0"
 
   role_name = "${var.eks_foxglove_namespace}-stream-service-sa-role"
 

--- a/primary-site/aws/provider.tf
+++ b/primary-site/aws/provider.tf
@@ -2,6 +2,13 @@
 terraform {
   required_version = ">= 1.3.2"
   backend "s3" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.100.0"
+    }
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
These are the minimally required changes and pin the underlying modules to get the examples to work as originally intended.

### Docs 

None 

### Description

Our AWS examples were failing due to breaking changes in the underlying modules that we did not have pinned. This PR pins the modules to a known working versions. 

I tested this out by running against my AWS sandbox account and was able to get terraform init, plan, and apply to work as expected. 

